### PR TITLE
Fix program build on g++; correct one small error

### DIFF
--- a/framework/src/node_editorwidget.cpp
+++ b/framework/src/node_editorwidget.cpp
@@ -19,7 +19,7 @@
 ****************************************************************************/
 
 // Include
-#include <QVBoxLayout>mview
+#include <QVBoxLayout>
 #include <QMessageBox>
 #include <QLabel>
 #include <QGraphicsSceneMouseEvent>

--- a/framework/src/ogre3_renderman.cpp
+++ b/framework/src/ogre3_renderman.cpp
@@ -38,7 +38,7 @@ namespace Magus
         mCompositorPassProvider = 0;
         mPause = true;
 
-        #ifdef _DEBUG
+        #if _DEBUG || DEBUG
             mResourcesCfg = "resources_d.cfg";
             mPluginsCfg = "plugins_d.cfg";
         #else

--- a/source/header/paintlayer_dockwidget.h
+++ b/source/header/paintlayer_dockwidget.h
@@ -99,7 +99,7 @@ class PaintLayerDockWidget : public QDockWidget
         /* Set/get the overflow type.
          */
         void setPaintOverflow(int layerId, const QString& paintOverflow);
-        const QString& PaintLayerDockWidget::getPaintOverflow(int layerId);
+        const QString& getPaintOverflow(int layerId);
 
         /* Set/get the Carbon Copy texture
          */

--- a/source/header/texturelayer.h
+++ b/source/header/texturelayer.h
@@ -44,7 +44,7 @@ class TextureSaveWorker : public QObject
     Q_OBJECT
 
     public:
-        TextureSaveWorker::TextureSaveWorker (const Ogre::Image& image, const Ogre::String& filename) :
+        TextureSaveWorker (const Ogre::Image& image, const Ogre::String& filename) :
             mImage(image)
         {
             mImage = image;


### PR DESCRIPTION
 - class constructor TextureSaveWorker constructor was "over qualified"
 in header (namespace TextureSaveWorker:: reapeted)

 - method const `QString& PaintLayerDockWidget::getPaintOverflow(int
 layerId)` was over qualified in the same way

 - somehow the string "mview" was pasted in the preprocessor include
 section of /framework/src/node_editorwidget.cpp

Signed-off-by: Arthur Brainville (Ybalrid) <ybalrid@ybalrid.info>