### PR TITLE
Stop returning referece to locally created Vector3/Quaternion

### DIFF
--- a/framework/header/ogre3_cameraman.h
+++ b/framework/header/ogre3_cameraman.h
@@ -492,7 +492,7 @@ namespace Magus
         /*-----------------------------------------------------------------------------
         | Return orientation
         -----------------------------------------------------------------------------*/
-        const Ogre::Quaternion& getOrientationCameraSceneNode (void)
+        const Ogre::Quaternion getOrientationCameraSceneNode (void)
         {
             return mCameraNode->getOrientation();
         }
@@ -500,7 +500,7 @@ namespace Magus
         /*-----------------------------------------------------------------------------
         | Return position
         -----------------------------------------------------------------------------*/
-        const Ogre::Vector3& getPositionCameraSceneNode (void)
+        const Ogre::Vector3 getPositionCameraSceneNode (void)
         {
             return mCameraNode->getPosition();
         }

--- a/framework/header/ogre3_widget.h
+++ b/framework/header/ogre3_widget.h
@@ -73,7 +73,7 @@ namespace Magus
             Ogre::Item* getItem(void) {return mItem;}
             Ogre::RenderWindow* getRenderWindow(void) {return mOgreRenderWindow;}
             Ogre::SceneManager* getSceneManager(void) {return mSceneManager;}
-            const Ogre::Vector3& getItemScale(void);
+            const Ogre::Vector3 getItemScale(void);
             void setItemScale(const Ogre::Vector3& scale);
             void setRotation(const Ogre::Vector3& rotation);
             void setPosition(const Ogre::Vector3& position);

--- a/framework/src/ogre3_widget.cpp
+++ b/framework/src/ogre3_widget.cpp
@@ -1301,10 +1301,13 @@ namespace Magus
     }
 
     //****************************************************************************/
-    const Ogre::Vector3& QOgreWidget::getItemScale(void)
+    const Ogre::Vector3 QOgreWidget::getItemScale(void)
     {
         if (mItem && mItem->getParentSceneNode())
             return mItem->getParentSceneNode()->getScale();
+
+        //Need to return on all code paths
+        return Ogre::Vector3::UNIT_SCALE; //vec3{1,1,1}
     }
 
     //****************************************************************************/


### PR DESCRIPTION
In the "cameraman" code, position/orientation was returned as const ref
to a localy created Vector3 or Quaternion object.

IIRC, in that case Visual Studio will create a copy of the object
anyway, but GCC won't, and will only print out a warning while doing
what the code is supposed to do.

That reference may be "dangling" and will not permit ot access the
object.

Ogre::SceneNode::getPosition/Orientation returns by value anyway
and modern C++ standard inforce Return Value Optimization.

This seems to be the cause of a segmentation fault when attempting to
move the camera on the main viewport of the applciation if build with
GCC on Linux.

Signed-off-by: Arthur Brainville (Ybalrid) <ybalrid@ybalrid.info>