### PR TITLE
Restore compatibility with head of Ogre v2-1 : Replace datablocks's `getFullName()` into `getNameStr()`

### DIFF
--- a/framework/src/ogre3_widget.cpp
+++ b/framework/src/ogre3_widget.cpp
@@ -480,7 +480,7 @@ namespace Magus
             // Delete the old item if available
             if (mItem)
             {
-                datablockFullName = *(mItem->getSubItem(0)->getDatablock()->getFullName());
+                datablockFullName = *(mItem->getSubItem(0)->getDatablock()->getNameStr());
                 setDefaultDatablockItem();
                 mSceneNode->detachAllObjects();
                 mSceneManager->destroyItem(mItem);
@@ -1494,7 +1494,7 @@ namespace Magus
             datablock = subItem->getDatablock();
             if (datablock)
             {
-                datablockFullName = *datablock->getFullName();
+                datablockFullName = *datablock->getNameStr();
                 // Exclude special datablocks
                 if (    datablock != hlmsPbs->getDefaultDatablock() &&
                         datablock != hlmsUnlit->getDefaultDatablock() &&
@@ -1531,7 +1531,7 @@ namespace Magus
                 {
                     try
                     {
-                        //Ogre::LogManager::getSingleton().logMessage("make snaphot: " +  *datablock->getFullName()); // DEBUG
+                        //Ogre::LogManager::getSingleton().logMessage("make snaphot: " +  *datablock->getNameStr()); // DEBUG
                         subItem->setDatablock(datablock->getName());
                     }
                     catch (Ogre::Exception e){}
@@ -1555,7 +1555,7 @@ namespace Magus
         while (itorPbs != endPbs)
         {
             datablock = itorPbs->second.datablock;
-            if (datablock && *datablock->getFullName() == fullName)
+            if (datablock && *datablock->getNameStr() == fullName)
                 return datablock;
 
             ++itorPbs;
@@ -1566,7 +1566,7 @@ namespace Magus
         while (itorUnlit != endUnlit)
         {
             datablock = itorUnlit->second.datablock;
-            if (datablock && *datablock->getFullName() == fullName)
+            if (datablock && *datablock->getNameStr() == fullName)
                 return datablock;
 
             ++itorUnlit;
@@ -1591,7 +1591,7 @@ namespace Magus
             datablock = subItem->getDatablock();
             if (datablock)
             {
-                datablockFullName = *datablock->getFullName();
+                datablockFullName = *datablock->getNameStr();
                 meshPtr->getSubMesh(i)->setMaterialName(datablockFullName);
             }
         }

--- a/source/src/hlms_pbs_builder.cpp
+++ b/source/src/hlms_pbs_builder.cpp
@@ -330,7 +330,7 @@ void HlmsPbsBuilder::enrichPbsNode(HlmsNodePbsDatablock* pbsnode,
                                    Ogre::HlmsPbsDatablock* datablock)
 {
     // ******** Name ********
-    pbsnode->setName(datablock->getFullName()->c_str());
+    pbsnode->setName(datablock->getNameStr()->c_str());
 
     // ******** Diffuse ********
     pbsnode->setDiffuseRed(255.0f * datablock->getDiffuse().x);

--- a/source/src/hlms_unlit_builder.cpp
+++ b/source/src/hlms_unlit_builder.cpp
@@ -311,7 +311,7 @@ void HlmsUnlitBuilder::enrichUnlitNode(HlmsNodeUnlitDatablock* unlitnode,
                                        Ogre::HlmsUnlitDatablock* datablock)
 {
     // ******** Name ********
-    unlitnode->setName(datablock->getFullName()->c_str());
+    unlitnode->setName(datablock->getNameStr()->c_str());
 
     // ******** Colour ********
     QColor colour;

--- a/source/src/hlms_utils_manager.cpp
+++ b/source/src/hlms_utils_manager.cpp
@@ -135,7 +135,7 @@ void HlmsUtilsManager::makeSnapshotDatablocks(void)
     {
         pbsDatablock = static_cast<Ogre::HlmsPbsDatablock*>(itorPbs->second.datablock);
         helperDatablockStruct.datablock = pbsDatablock;
-        helperDatablockStruct.datablockFullName = *pbsDatablock->getFullName();
+        helperDatablockStruct.datablockFullName = *pbsDatablock->getNameStr();
         helperDatablockStruct.datablockId = pbsDatablock->getName();
         helperDatablockStruct.jsonFileName = "";
         helperDatablockStruct.type = HLMS_PBS;
@@ -155,7 +155,7 @@ void HlmsUtilsManager::makeSnapshotDatablocks(void)
     {
         unlitDatablock = static_cast<Ogre::HlmsUnlitDatablock*>(itorUnlit->second.datablock);
         helperDatablockStruct.datablock = unlitDatablock;
-        helperDatablockStruct.datablockFullName = *unlitDatablock->getFullName();
+        helperDatablockStruct.datablockFullName = *unlitDatablock->getNameStr();
         helperDatablockStruct.datablockId = unlitDatablock->getName();
         helperDatablockStruct.jsonFileName = "";
         helperDatablockStruct.type = HLMS_UNLIT;
@@ -199,7 +199,7 @@ HlmsUtilsManager::DatablockStruct HlmsUtilsManager::compareSnapshotWithRegistere
     {
         pbsDatablock = static_cast<Ogre::HlmsPbsDatablock*>(itorPbs->second.datablock);
         ogreDatablockStruct.datablock = pbsDatablock;
-        ogreDatablockStruct.datablockFullName = *pbsDatablock->getFullName();
+        ogreDatablockStruct.datablockFullName = *pbsDatablock->getNameStr();
         ogreDatablockStruct.datablockId = pbsDatablock->getName();
         ogreDatablockStruct.jsonFileName = "";
         ogreDatablockStruct.type = HLMS_PBS;
@@ -237,7 +237,7 @@ HlmsUtilsManager::DatablockStruct HlmsUtilsManager::compareSnapshotWithRegistere
     {
         unlitDatablock = static_cast<Ogre::HlmsUnlitDatablock*>(itorUnlit->second.datablock);
         ogreDatablockStruct.datablock = unlitDatablock;
-        ogreDatablockStruct.datablockFullName = *unlitDatablock->getFullName();
+        ogreDatablockStruct.datablockFullName = *unlitDatablock->getNameStr();
         ogreDatablockStruct.datablockId = unlitDatablock->getName();
         ogreDatablockStruct.jsonFileName = "";
         ogreDatablockStruct.type = HLMS_UNLIT;
@@ -397,7 +397,7 @@ void HlmsUtilsManager::destroyDatablocks(bool excludeSpecialDatablocks,
     while( itorPbs != endPbs)
     {
         pbsDatablock = static_cast<Ogre::HlmsPbsDatablock*>(itorPbs->second.datablock);
-        fullName = *pbsDatablock->getFullName();
+        fullName = *pbsDatablock->getNameStr();
 
         // Default datablocks are NEVER detroyed
         exclude = pbsDatablock == hlmsPbs->getDefaultDatablock() || pbsDatablock == hlmsUnlit->getDefaultDatablock();
@@ -438,7 +438,7 @@ void HlmsUtilsManager::destroyDatablocks(bool excludeSpecialDatablocks,
     while( itorUnlit != endUnlit)
     {
         unlitDatablock = static_cast<Ogre::HlmsUnlitDatablock*>(itorUnlit->second.datablock);
-        fullName = *unlitDatablock->getFullName();
+        fullName = *unlitDatablock->getNameStr();
 
         // Default datablocks are NEVER detroyed
         exclude = unlitDatablock == hlmsPbs->getDefaultDatablock() || unlitDatablock == hlmsUnlit->getDefaultDatablock();
@@ -490,7 +490,7 @@ void HlmsUtilsManager::destroyDatablocks(bool excludeSpecialDatablocks,
         pbsDatablock = itPbsToBeDestroyed.next();
         if (pbsDatablock)
         {
-            //Ogre::LogManager::getSingleton().logMessage("Destroying Pbs: " + *pbsDatablock->getFullName()); // DEBUG
+            //Ogre::LogManager::getSingleton().logMessage("Destroying Pbs: " + *pbsDatablock->getNameStr()); // DEBUG
             // Only destroy the datablocks. In principle The textures should also be destroyed (using destroyAllTextures...), but this only causes large wait times
             hlmsPbs->destroyDatablock(pbsDatablock->getName());
         }
@@ -503,7 +503,7 @@ void HlmsUtilsManager::destroyDatablocks(bool excludeSpecialDatablocks,
         unlitDatablock = itUnlitToBeDestroyed.next();
         if (unlitDatablock)
         {
-            //Ogre::LogManager::getSingleton().logMessage("Destroying Unlit: " + *unlitDatablock->getFullName()); // DEBUG
+            //Ogre::LogManager::getSingleton().logMessage("Destroying Unlit: " + *unlitDatablock->getNameStr()); // DEBUG
             // Only destroy the datablocks. In principle The textures should also be destroyed (using destroyAllTextures...), but this only causes large wait times
             hlmsUnlit->destroyDatablock(unlitDatablock->getName());
         }
@@ -952,7 +952,7 @@ HlmsUtilsManager::DatablockStruct HlmsUtilsManager::getDatablock(const Ogre::IdS
         if (pbsDatablock->getName() == datablockId)
         {
             helperDatablockStruct.datablock = pbsDatablock;
-            helperDatablockStruct.datablockFullName = *pbsDatablock->getFullName();
+            helperDatablockStruct.datablockFullName = *pbsDatablock->getNameStr();
             helperDatablockStruct.datablockId = pbsDatablock->getName();
             helperDatablockStruct.jsonFileName = "";
             helperDatablockStruct.type = HLMS_PBS;
@@ -972,7 +972,7 @@ HlmsUtilsManager::DatablockStruct HlmsUtilsManager::getDatablock(const Ogre::IdS
         if (unlitDatablock->getName() == datablockId)
         {
             helperDatablockStruct.datablock = unlitDatablock;
-            helperDatablockStruct.datablockFullName = *unlitDatablock->getFullName();
+            helperDatablockStruct.datablockFullName = *unlitDatablock->getNameStr();
             helperDatablockStruct.datablockId = unlitDatablock->getName();
             helperDatablockStruct.jsonFileName = "";
             helperDatablockStruct.type = HLMS_UNLIT;

--- a/source/src/nodeeditor_dockwidget.cpp
+++ b/source/src/nodeeditor_dockwidget.cpp
@@ -360,7 +360,7 @@ void NodeEditorDockWidget::doCogHToolbarAction(void)
         if (datablock)
         {
             mParent->replaceCurrentDatablock(indices, datablock->getName());
-            mParent->setCurrentDatablockIdAndFullName(datablock->getName(), *datablock->getFullName());
+            mParent->setCurrentDatablockIdAndFullName(datablock->getName(), *datablock->getNameStr());
             hlmsUtilsManager->addNewDatablockToRegisteredDatablocks(currentName, jsonFileName);
         }
     }
@@ -386,7 +386,7 @@ void NodeEditorDockWidget::doCogHToolbarAction(void)
         if (datablock)
         {
             mParent->replaceCurrentDatablock(indices, datablock->getName());
-            mParent->setCurrentDatablockIdAndFullName(datablock->getName(), *datablock->getFullName());
+            mParent->setCurrentDatablockIdAndFullName(datablock->getName(), *datablock->getNameStr());
             hlmsUtilsManager->addNewDatablockToRegisteredDatablocks(currentName, jsonFileName);
         }
     }


### PR DESCRIPTION
To make the program compatible with current head of v2-1 branch of Ogre

Signed-off-by: Arthur Brainville (Ybalrid) <ybalrid@ybalrid.info>