### PR TITLE
Fix magus generated header for GCC

### DIFF
--- a/framework/header/tool_generic_assetwidget.h
+++ b/framework/header/tool_generic_assetwidget.h
@@ -117,7 +117,7 @@ namespace Magus
 
             // Returns true if the asset exists. Use the full qualified name as search criterium if nameIsFullName = true;
             // else use the baseName as search criterium.
-            bool QtGenericAssetWidget::assetExists(const QString& name, bool nameIsFullName = true);
+            bool assetExists(const QString& name, bool nameIsFullName = true);
 
             // Delete an item from the QtGenericAssetWidget. Use the full qualified name as search criterium if nameIsFullName = true;
             // else use the baseName as search criterium.


### PR DESCRIPTION
Remove over qualification of symbol in header

This fix was proposed in #16 by @nic96, but alongside other changes. 

Since it's **necessary** for building it on GCC (Linux), I propose to integrate it independently. 

I also want to investigate your Magus project about this issue, since it looks like these errors came from some generated code. I've opened an issue there : https://github.com/spookyboo/Magus/issues/1