### PR TITLE
Copy missing resources directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,10 @@ if(UNIX)
 	file(COPY ${OGRE_MEDIA_DIR}/../plugins.cfg DESTINATION ${CMAKE_BINARY_DIR})
 	file(COPY ${OGRE_MEDIA_DIR}/../plugins_d.cfg DESTINATION ${CMAKE_BINARY_DIR})
 
+        #install resources
+        file(COPY ${PROJECT_SOURCE_DIR}/common
+            DESTINATION ${CMAKE_BINARY_DIR}/../)
+
 	#install resources from /bin
 	file(COPY ${PROJECT_SOURCE_DIR}/bin/resources.cfg ${PROJECT_SOURCE_DIR}/bin/resources_d.cfg
 			${PROJECT_SOURCE_DIR}/bin/resources_default.cfg ${PROJECT_SOURCE_DIR}/bin/settings.cfg


### PR DESCRIPTION
the resources directory common was missing at the subdirectory of the binary directory after running cmake therefore when trying to run HLMSEditor I get this output:
`terminate called after throwing an instance of 'Ogre::FileNotFoundException'
  what():  OGRE EXCEPTION(6:FileNotFoundException): Cannot locate resource barrel.mesh in resource group General or any other group. in ResourceGroupManager::openResource at /home/user/workspace/ogre/OgreMain/src/OgreResourceGroupManager.cpp (line 758)
The program has unexpectedly finished.`